### PR TITLE
fix(backend) allow custom backend url to be set optionally.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 PLEXGUARD_FRONTEND_PORT=3000
 VERSION=latest
+# optional variable to specifically set internal link to backend
+# BACKEND_URL: http://localhost:3001

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,6 +22,8 @@ services:
       - "${PLEXGUARD_FRONTEND_PORT:-3000}:3000"
     environment:
       NODE_ENV: production
+      # optional variable to specifically set internal link to backend
+      # BACKEND_URL: http://localhost:3001
     depends_on:
       - backend
     restart: unless-stopped

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,6 +17,8 @@ services:
       - "${PLEXGUARD_FRONTEND_PORT:-3000}:3000"
     environment:
       NODE_ENV: production
+      # optional variable to specifically set internal link to backend
+      # BACKEND_URL: http://localhost:3001
     depends_on:
       - backend
     restart: unless-stopped

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,4 +1,27 @@
+/**
+ * Checks if a string is a valid URL.
+ */
+function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns the backend URL for the application, based on environment variables.
+ */
 function getBackendUrl(): string {
+  const backendUrl = process.env.BACKEND_URL;
+
+  // If BACKEND_URL is defined and valid, normalize and return it
+  if (backendUrl && isValidUrl(backendUrl)) {
+    return new URL(backendUrl).toString().replace(/\/$/, "");
+  }
+
+  // If invalid or not defined, choose default based on DEPLOYMENT_MODE
   return process.env.DEPLOYMENT_MODE === "standalone"
     ? "http://localhost:3001"
     : "http://backend:3001";

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,10 +1,5 @@
 import type { NextConfig } from "next";
-
-function getBackendUrl(): string {
-  return process.env.DEPLOYMENT_MODE === "standalone"
-    ? "http://localhost:3001"
-    : "http://backend:3001";
-}
+import { getBackendUrl } from './lib/config';
 
 const nextConfig: NextConfig = {
   output: "standalone",


### PR DESCRIPTION
i kept the changes very minimal; i move the backendUrl logic strictly to libs/config only so its not written in multiple places and updated the .env.example and docker composes yamls to reflect the changes with comments (its commented out) as the old code is will take over if the backend_url variable isnt set.