### PR TITLE
fix: add IPv6 support to IP validation service

### DIFF
--- a/backend/src/common/services/ip-validation.service.spec.ts
+++ b/backend/src/common/services/ip-validation.service.spec.ts
@@ -1,0 +1,397 @@
+import { IPValidationService, NetworkPolicy } from './ip-validation.service';
+
+describe('IPValidationService', () => {
+  let service: IPValidationService;
+
+  beforeEach(() => {
+    service = new IPValidationService();
+  });
+
+  const basePolicy: NetworkPolicy = {
+    networkPolicy: 'both',
+    ipAccessPolicy: 'all',
+    allowedIPs: [],
+  };
+
+  describe('isValidIPv4', () => {
+    it('accepts a valid dotted-quad address', () => {
+      expect(service.isValidIPv4('192.168.1.1')).toBe(true);
+    });
+
+    it('rejects an octet above 255', () => {
+      expect(service.isValidIPv4('256.1.1.1')).toBe(false);
+    });
+
+    it('rejects an IPv6 address', () => {
+      expect(service.isValidIPv4('2001:db8::1')).toBe(false);
+    });
+
+    it('rejects garbage input', () => {
+      expect(service.isValidIPv4('not-an-ip')).toBe(false);
+    });
+  });
+
+  describe('isValidIPv6', () => {
+    it('accepts the loopback address', () => {
+      expect(service.isValidIPv6('::1')).toBe(true);
+    });
+
+    it('accepts a compressed global unicast address', () => {
+      expect(service.isValidIPv6('2001:db8::1')).toBe(true);
+    });
+
+    it('accepts a fully expanded address', () => {
+      expect(
+        service.isValidIPv6('2001:0db8:0000:0000:0000:0000:0000:0001'),
+      ).toBe(true);
+    });
+
+    it('accepts an IPv4-mapped address', () => {
+      expect(service.isValidIPv6('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    it('accepts a link-local address with a zone index', () => {
+      expect(service.isValidIPv6('fe80::1%eth0')).toBe(true);
+    });
+
+    it('rejects an IPv4 address', () => {
+      expect(service.isValidIPv6('192.168.1.1')).toBe(false);
+    });
+
+    it('rejects garbage input', () => {
+      expect(service.isValidIPv6('not-an-ip')).toBe(false);
+    });
+
+    it('rejects an address with an invalid hex group', () => {
+      expect(service.isValidIPv6('2001:db8::g')).toBe(false);
+    });
+  });
+
+  describe('isValidIP', () => {
+    it('accepts a valid IPv4 address', () => {
+      expect(service.isValidIP('10.0.0.1')).toBe(true);
+    });
+
+    it('accepts a valid IPv6 address', () => {
+      expect(service.isValidIP('2001:db8::1')).toBe(true);
+    });
+
+    it('rejects garbage input', () => {
+      expect(service.isValidIP('not-an-ip')).toBe(false);
+    });
+  });
+
+  describe('isValidCIDRv6', () => {
+    it('accepts a valid IPv6 CIDR', () => {
+      expect(service.isValidCIDRv6('2001:db8::/32')).toBe(true);
+    });
+
+    it('accepts prefix length 0 and 128 (boundary)', () => {
+      expect(service.isValidCIDRv6('::/0')).toBe(true);
+      expect(service.isValidCIDRv6('::1/128')).toBe(true);
+    });
+
+    it('rejects a prefix length above 128', () => {
+      expect(service.isValidCIDRv6('2001:db8::/129')).toBe(false);
+    });
+
+    it('rejects an IPv4 CIDR', () => {
+      expect(service.isValidCIDRv6('192.168.1.0/24')).toBe(false);
+    });
+
+    it('rejects a plain address without a prefix', () => {
+      expect(service.isValidCIDRv6('2001:db8::1')).toBe(false);
+    });
+  });
+
+  describe('normalizeIP', () => {
+    it('normalizes an IPv4-mapped IPv6 address to its IPv4 form', () => {
+      expect(service.normalizeIP('::ffff:192.168.1.10')).toBe('192.168.1.10');
+    });
+
+    it('normalizes the hex-group form of an IPv4-mapped address', () => {
+      expect(service.normalizeIP('::ffff:c0a8:10a')).toBe('192.168.1.10');
+    });
+
+    it('leaves a plain IPv4 address unchanged', () => {
+      expect(service.normalizeIP('192.168.1.10')).toBe('192.168.1.10');
+    });
+
+    it('leaves a "real" (non-mapped) IPv6 address unchanged', () => {
+      expect(service.normalizeIP('2001:db8::1')).toBe('2001:db8::1');
+    });
+
+    it('leaves an invalid address unchanged (trimmed)', () => {
+      expect(service.normalizeIP('  not-an-ip  ')).toBe('not-an-ip');
+    });
+  });
+
+  describe('isPrivateIP', () => {
+    // --- IPv4 (pre-existing behaviour, must stay unchanged) ---
+    it('treats 10.0.0.0/8 as private', () => {
+      expect(service.isPrivateIP('10.1.2.3')).toBe(true);
+    });
+
+    it('treats 172.16.0.0/12 as private', () => {
+      expect(service.isPrivateIP('172.20.0.1')).toBe(true);
+      expect(service.isPrivateIP('172.15.0.1')).toBe(false);
+      expect(service.isPrivateIP('172.32.0.1')).toBe(false);
+    });
+
+    it('treats 192.168.0.0/16 as private', () => {
+      expect(service.isPrivateIP('192.168.1.1')).toBe(true);
+    });
+
+    it('treats 127.0.0.0/8 as private', () => {
+      expect(service.isPrivateIP('127.0.0.1')).toBe(true);
+    });
+
+    it('treats a public IPv4 address as not private', () => {
+      expect(service.isPrivateIP('8.8.8.8')).toBe(false);
+    });
+
+    // --- IPv6 ---
+    it('treats ::1 (loopback) as private', () => {
+      expect(service.isPrivateIP('::1')).toBe(true);
+    });
+
+    it('treats fc00::/7 (unique local) as private', () => {
+      expect(service.isPrivateIP('fc00::1')).toBe(true);
+      expect(service.isPrivateIP('fdff:ffff::1')).toBe(true);
+      expect(service.isPrivateIP('fe00::1')).toBe(false);
+    });
+
+    it('treats fe80::/10 (link-local) as private', () => {
+      expect(service.isPrivateIP('fe80::1')).toBe(true);
+      expect(service.isPrivateIP('febf:ffff::1')).toBe(true);
+      expect(service.isPrivateIP('fec0::1')).toBe(false);
+    });
+
+    it('treats a public IPv6 (GUA) address as not private', () => {
+      expect(service.isPrivateIP('2001:db8::1')).toBe(false);
+    });
+
+    // --- IPv4-mapped IPv6 must classify exactly like its IPv4 form ---
+    it('treats an IPv4-mapped private address as private', () => {
+      expect(service.isPrivateIP('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    it('treats an IPv4-mapped public address as not private', () => {
+      expect(service.isPrivateIP('::ffff:8.8.8.8')).toBe(false);
+    });
+
+    it('returns false for an invalid address', () => {
+      expect(service.isPrivateIP('not-an-ip')).toBe(false);
+    });
+  });
+
+  describe('getNetworkType', () => {
+    it('classifies a private IPv4 address as lan', () => {
+      expect(service.getNetworkType('192.168.1.1')).toBe('lan');
+    });
+
+    it('classifies a public IPv4 address as wan', () => {
+      expect(service.getNetworkType('8.8.8.8')).toBe('wan');
+    });
+
+    it('classifies a private IPv6 address as lan', () => {
+      expect(service.getNetworkType('fd12:3456:789a::1')).toBe('lan');
+    });
+
+    it('classifies a public IPv6 address as wan', () => {
+      expect(service.getNetworkType('2001:db8::1')).toBe('wan');
+    });
+
+    it('classifies an IPv4-mapped private IPv6 address as lan', () => {
+      expect(service.getNetworkType('::ffff:10.0.0.5')).toBe('lan');
+    });
+
+    it('returns unknown for an invalid address', () => {
+      expect(service.getNetworkType('not-an-ip')).toBe('unknown');
+    });
+  });
+
+  describe('isIPInCIDR', () => {
+    // --- IPv4 (pre-existing behaviour) ---
+    it('matches an IPv4 address inside the range', () => {
+      expect(service.isIPInCIDR('192.168.1.42', '192.168.1.0/24')).toBe(true);
+    });
+
+    it('rejects an IPv4 address outside the range', () => {
+      expect(service.isIPInCIDR('192.168.2.42', '192.168.1.0/24')).toBe(false);
+    });
+
+    // --- IPv6 ---
+    it('matches an IPv6 address inside the range', () => {
+      expect(service.isIPInCIDR('2001:db8:1234::5', '2001:db8::/32')).toBe(
+        true,
+      );
+    });
+
+    it('rejects an IPv6 address outside the range', () => {
+      expect(service.isIPInCIDR('2001:db9::5', '2001:db8::/32')).toBe(false);
+    });
+
+    it('matches exactly at the CIDR boundary (single-host /128)', () => {
+      expect(service.isIPInCIDR('::1', '::1/128')).toBe(true);
+      expect(service.isIPInCIDR('::2', '::1/128')).toBe(false);
+    });
+
+    // --- cross-family: must never match ---
+    it('does not match an IPv4 address against an IPv6 CIDR', () => {
+      expect(service.isIPInCIDR('192.168.1.1', '2001:db8::/32')).toBe(false);
+    });
+
+    it('does not match an IPv6 address against an IPv4 CIDR', () => {
+      expect(service.isIPInCIDR('2001:db8::1', '192.168.1.0/24')).toBe(false);
+    });
+
+    it('matches an IPv4-mapped IPv6 address against an IPv4 CIDR', () => {
+      expect(service.isIPInCIDR('::ffff:192.168.1.42', '192.168.1.0/24')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('isIPInAllowedList', () => {
+    it('allows any IP when the list is empty', () => {
+      expect(service.isIPInAllowedList('8.8.8.8', [])).toBe(true);
+    });
+
+    it('matches an exact IPv4 entry', () => {
+      expect(service.isIPInAllowedList('192.168.1.5', ['192.168.1.5'])).toBe(
+        true,
+      );
+    });
+
+    it('matches an IPv4 CIDR entry', () => {
+      expect(service.isIPInAllowedList('192.168.1.5', ['192.168.1.0/24'])).toBe(
+        true,
+      );
+    });
+
+    it('rejects an IPv4 address not covered by the list', () => {
+      expect(service.isIPInAllowedList('10.0.0.1', ['192.168.1.0/24'])).toBe(
+        false,
+      );
+    });
+
+    it('matches an exact IPv6 entry', () => {
+      expect(service.isIPInAllowedList('2001:db8::1', ['2001:db8::1'])).toBe(
+        true,
+      );
+    });
+
+    it('matches an IPv6 CIDR entry', () => {
+      expect(service.isIPInAllowedList('2001:db8::1', ['2001:db8::/32'])).toBe(
+        true,
+      );
+    });
+
+    it('rejects an IPv6 address not covered by the list', () => {
+      expect(service.isIPInAllowedList('2001:db9::1', ['2001:db8::/32'])).toBe(
+        false,
+      );
+    });
+
+    it('matches against a mixed IPv4/IPv6 allow list', () => {
+      const allowed = ['192.168.1.0/24', '2001:db8::/32'];
+      expect(service.isIPInAllowedList('192.168.1.42', allowed)).toBe(true);
+      expect(service.isIPInAllowedList('2001:db8::42', allowed)).toBe(true);
+      expect(service.isIPInAllowedList('10.0.0.1', allowed)).toBe(false);
+      expect(service.isIPInAllowedList('2001:db9::1', allowed)).toBe(false);
+    });
+
+    it('matches an IPv4-mapped client against a plain IPv4 allow entry', () => {
+      expect(
+        service.isIPInAllowedList('::ffff:192.168.1.5', ['192.168.1.5']),
+      ).toBe(true);
+    });
+
+    it('rejects an invalid client address', () => {
+      expect(service.isIPInAllowedList('not-an-ip', ['192.168.1.5'])).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('validateIPAccess', () => {
+    it('allows a private IPv4 client under the default policy', () => {
+      expect(service.validateIPAccess('192.168.1.5', basePolicy).allowed).toBe(
+        true,
+      );
+    });
+
+    it('rejects a missing client IP', () => {
+      const result = service.validateIPAccess('', basePolicy);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Invalid or missing client IP address');
+    });
+
+    it('rejects a syntactically invalid client IP', () => {
+      const result = service.validateIPAccess('not-an-ip', basePolicy);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe('Invalid or missing client IP address');
+    });
+
+    // --- this is the regression test for the reported bug ---
+    it('no longer rejects a well-formed IPv6 client under a permissive policy', () => {
+      const result = service.validateIPAccess('2001:db8::1', basePolicy);
+      expect(result.allowed).toBe(true);
+    });
+
+    it('enforces a lan-only policy against an IPv6 client', () => {
+      const policy: NetworkPolicy = { ...basePolicy, networkPolicy: 'lan' };
+
+      const lanResult = service.validateIPAccess('fd12:3456:789a::1', policy);
+      expect(lanResult.allowed).toBe(true);
+
+      const wanResult = service.validateIPAccess('2001:db8::1', policy);
+      expect(wanResult.allowed).toBe(false);
+      expect(wanResult.stopCode).toBe('IP_POLICY_LAN_ONLY');
+    });
+
+    it('enforces a wan-only policy against an IPv6 client', () => {
+      const policy: NetworkPolicy = { ...basePolicy, networkPolicy: 'wan' };
+
+      const wanResult = service.validateIPAccess('2001:db8::1', policy);
+      expect(wanResult.allowed).toBe(true);
+
+      const lanResult = service.validateIPAccess('fd12:3456:789a::1', policy);
+      expect(lanResult.allowed).toBe(false);
+      expect(lanResult.stopCode).toBe('IP_POLICY_WAN_ONLY');
+    });
+
+    it('enforces a restricted allow list against an IPv6 client', () => {
+      const policy: NetworkPolicy = {
+        ...basePolicy,
+        ipAccessPolicy: 'restricted',
+        allowedIPs: ['2001:db8::/32'],
+      };
+
+      const allowed = service.validateIPAccess('2001:db8::42', policy);
+      expect(allowed.allowed).toBe(true);
+
+      const denied = service.validateIPAccess('2001:db9::1', policy);
+      expect(denied.allowed).toBe(false);
+      expect(denied.stopCode).toBe('IP_POLICY_NOT_ALLOWED');
+    });
+
+    it('does not silently reclassify a real IPv6 WAN client as lan', () => {
+      // Guards against a naive "treat every IPv6 address as WAN" or
+      // "treat every IPv6 address as unclassified/lan" implementation,
+      // which would change the meaning of an existing lan-only policy.
+      const policy: NetworkPolicy = { ...basePolicy, networkPolicy: 'lan' };
+      const result = service.validateIPAccess('2001:db8::1', policy);
+      expect(result.allowed).toBe(false);
+    });
+
+    it('uses the provided custom messages for IPv6 policy rejections', () => {
+      const policy: NetworkPolicy = { ...basePolicy, networkPolicy: 'lan' };
+      const result = service.validateIPAccess('2001:db8::1', policy, {
+        lanOnly: 'custom lan message',
+      });
+      expect(result.reason).toBe('custom lan message');
+    });
+  });
+});

--- a/backend/src/common/services/ip-validation.service.ts
+++ b/backend/src/common/services/ip-validation.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import * as net from 'net';
 
 export type NetworkType = 'lan' | 'wan' | 'unknown';
 
@@ -18,6 +19,7 @@ export interface NetworkPolicy {
  * IP Validation Service
  *
  * Handles IP address validation, CIDR matching, and network policy enforcement.
+ * Supports both IPv4 and IPv6 addresses.
  */
 @Injectable()
 export class IPValidationService {
@@ -30,33 +32,90 @@ export class IPValidationService {
     return ipRegex.test(ip.trim());
   }
 
-  /** Validates if a CIDR notation is in valid format */
+  /** Validates if an IPv6 address is in valid format (zone index, e.g. "%eth0", is accepted) */
+  isValidIPv6(ip: string): boolean {
+    return net.isIPv6(ip.trim());
+  }
+
+  /** Validates if an address is a valid IPv4 or IPv6 address */
+  isValidIP(ip: string): boolean {
+    return this.isValidIPv4(ip) || this.isValidIPv6(ip);
+  }
+
+  /** Validates if a CIDR notation is in valid IPv4 format */
   isValidCIDR(cidr: string): boolean {
     const cidrRegex =
       /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(?:[0-9]|[1-2][0-9]|3[0-2])$/;
     return cidrRegex.test(cidr.trim());
   }
 
+  /** Validates if a CIDR notation is in valid IPv6 format */
+  isValidCIDRv6(cidr: string): boolean {
+    const trimmed = cidr.trim();
+    const slashIndex = trimmed.lastIndexOf('/');
+    if (slashIndex === -1) return false;
+
+    const address = trimmed.slice(0, slashIndex);
+    const prefixText = trimmed.slice(slashIndex + 1);
+    if (!/^\d+$/.test(prefixText)) return false;
+
+    const prefix = Number(prefixText);
+    return prefix >= 0 && prefix <= 128 && this.isValidIPv6(address);
+  }
+
+  /**
+   * Normalizes an IPv4-mapped IPv6 address (e.g. "::ffff:192.0.2.1") to its
+   * plain IPv4 form, so a dual-stack client is classified consistently
+   * regardless of which form it arrives in. Any other address (IPv4 or
+   * "real" IPv6) is returned trimmed and otherwise unchanged.
+   */
+  normalizeIP(ip: string): string {
+    const trimmed = ip.trim();
+    if (!this.isValidIPv6(trimmed)) return trimmed;
+
+    const value = this.ipv6ToBigInt(trimmed);
+    const isIPv4Mapped = value >> 32n === 0xffffn;
+    if (!isIPv4Mapped) return trimmed;
+
+    const ipv4Value = Number(value & 0xffffffffn);
+    const octets = [24, 16, 8, 0].map((shift) => (ipv4Value >>> shift) & 0xff);
+    return octets.join('.');
+  }
+
   /** Checks if an IP address is in a private range (LAN) */
   isPrivateIP(ip: string): boolean {
-    if (!this.isValidIPv4(ip)) return false;
-    const parts = ip.split('.').map(Number);
-    const [a, b] = parts;
-    return (
-      a === 10 ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      a === 127
-    );
+    const normalized = this.normalizeIP(ip);
+
+    if (this.isValidIPv4(normalized)) {
+      const parts = normalized.split('.').map(Number);
+      const [a, b] = parts;
+      return (
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        a === 127
+      );
+    }
+
+    if (this.isValidIPv6(normalized)) {
+      // ::1/128 (loopback), fc00::/7 (unique local), fe80::/10 (link-local)
+      return (
+        this.isIPInCIDR(normalized, '::1/128') ||
+        this.isIPInCIDR(normalized, 'fc00::/7') ||
+        this.isIPInCIDR(normalized, 'fe80::/10')
+      );
+    }
+
+    return false;
   }
 
   /** Determines the network type (LAN/WAN) of an IP address */
   getNetworkType(ip: string): NetworkType {
-    if (!this.isValidIPv4(ip)) return 'unknown';
+    if (!this.isValidIP(ip)) return 'unknown';
     return this.isPrivateIP(ip) ? 'lan' : 'wan';
   }
 
-  /** Converts IP address to numeric value for comparison */
+  /** Converts an IPv4 address to a numeric value for comparison */
   private ipToNumber(ip: string): number {
     return (
       ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet), 0) >>>
@@ -64,27 +123,95 @@ export class IPValidationService {
     );
   }
 
-  /** Checks if an IP address is within a CIDR range */
-  isIPInCIDR(ip: string, cidr: string): boolean {
-    if (!this.isValidIPv4(ip) || !this.isValidCIDR(cidr)) return false;
-    const [network, prefixLength] = cidr.split('/');
-    const ipNum = this.ipToNumber(ip);
-    const networkNum = this.ipToNumber(network);
-    const mask = (0xffffffff << (32 - parseInt(prefixLength))) >>> 0;
-    return (ipNum & mask) === (networkNum & mask);
+  /** Strips the zone index (e.g. "%eth0") from an IPv6 address, if present */
+  private stripZoneIndex(ip: string): string {
+    const percentIndex = ip.indexOf('%');
+    return percentIndex === -1 ? ip : ip.slice(0, percentIndex);
   }
 
-  /** Checks if client IP is in allowed list (supports IPs and CIDR ranges) */
+  /** Expands a trailing embedded IPv4 dotted-quad (e.g. "192.0.2.1") into two hex groups */
+  private expandEmbeddedIPv4(groups: string[]): string[] {
+    if (groups.length === 0) return groups;
+    const last = groups[groups.length - 1];
+    if (!last.includes('.')) return groups;
+
+    const octets = last.split('.').map(Number);
+    const hi = ((octets[0] << 8) | octets[1]).toString(16);
+    const lo = ((octets[2] << 8) | octets[3]).toString(16);
+    return [...groups.slice(0, -1), hi, lo];
+  }
+
+  /** Converts a validated IPv6 address to its 128-bit numeric value */
+  private ipv6ToBigInt(ip: string): bigint {
+    const address = this.stripZoneIndex(ip.trim());
+    const parts = address.split('::');
+    let groups: string[];
+
+    if (parts.length === 2) {
+      const [head, tail] = parts;
+      const headGroups = head ? head.split(':') : [];
+      const tailGroups = this.expandEmbeddedIPv4(tail ? tail.split(':') : []);
+      const missing = 8 - (headGroups.length + tailGroups.length);
+      const zeroGroups = Array<string>(missing).fill('0');
+      groups = [...headGroups, ...zeroGroups, ...tailGroups];
+    } else {
+      groups = this.expandEmbeddedIPv4(address.split(':'));
+    }
+
+    return groups.reduce(
+      (acc, group) => (acc << 16n) | BigInt(parseInt(group || '0', 16)),
+      0n,
+    );
+  }
+
+  /** Builds a 128-bit network mask for the given IPv6 CIDR prefix length */
+  private ipv6Mask(prefixLength: number): bigint {
+    const fullMask = (1n << 128n) - 1n;
+    const hostBits = BigInt(128 - prefixLength);
+    return fullMask ^ ((1n << hostBits) - 1n);
+  }
+
+  /** Checks if an IP address is within a CIDR range (IPv4 or IPv6) */
+  isIPInCIDR(ip: string, cidr: string): boolean {
+    const normalizedIP = this.normalizeIP(ip);
+    const trimmedCidr = cidr.trim();
+
+    if (this.isValidIPv4(normalizedIP)) {
+      if (!this.isValidCIDR(trimmedCidr)) return false;
+      const [network, prefixLength] = trimmedCidr.split('/');
+      const ipNum = this.ipToNumber(normalizedIP);
+      const networkNum = this.ipToNumber(network);
+      const mask = (0xffffffff << (32 - parseInt(prefixLength))) >>> 0;
+      return (ipNum & mask) === (networkNum & mask);
+    }
+
+    if (this.isValidIPv6(normalizedIP)) {
+      if (!this.isValidCIDRv6(trimmedCidr)) return false;
+      const slashIndex = trimmedCidr.lastIndexOf('/');
+      const network = trimmedCidr.slice(0, slashIndex);
+      const prefixLength = Number(trimmedCidr.slice(slashIndex + 1));
+      const mask = this.ipv6Mask(prefixLength);
+      return (
+        (this.ipv6ToBigInt(normalizedIP) & mask) ===
+        (this.ipv6ToBigInt(network) & mask)
+      );
+    }
+
+    return false;
+  }
+
+  /** Checks if client IP is in allowed list (supports IPv4/IPv6 addresses and CIDR ranges) */
   isIPInAllowedList(clientIP: string, allowedIPs: string[]): boolean {
-    if (!this.isValidIPv4(clientIP)) return false;
+    const normalizedClientIP = this.normalizeIP(clientIP);
+    if (!this.isValidIP(normalizedClientIP)) return false;
     if (!allowedIPs.length) return true;
 
     for (const allowed of allowedIPs) {
       const trimmed = allowed.trim();
-      if (this.isValidIPv4(trimmed)) {
-        if (clientIP === trimmed) return true;
-      } else if (this.isValidCIDR(trimmed)) {
-        if (this.isIPInCIDR(clientIP, trimmed)) return true;
+      if (this.isValidIP(trimmed)) {
+        if (normalizedClientIP === this.normalizeIP(trimmed)) return true;
+      } else if (this.isValidCIDR(trimmed) || this.isValidCIDRv6(trimmed)) {
+        if (this.isIPInCIDR(normalizedClientIP, trimmed)) return true;
       }
     }
     return false;
@@ -100,7 +227,7 @@ export class IPValidationService {
       notAllowed?: string;
     } = {},
   ): IPValidationResult {
-    if (!clientIP || !this.isValidIPv4(clientIP)) {
+    if (!clientIP || !this.isValidIP(clientIP)) {
       return {
         allowed: false,
         reason: 'Invalid or missing client IP address',


### PR DESCRIPTION
## Problem

Any Plex client connecting over IPv6 has its stream terminated with "Invalid or missing client IP address", because `validateIPAccess()` in `backend/src/common/services/ip-validation.service.ts` rejects any address that fails the strict IPv4 regex, **before** any user policy is evaluated. `isPrivateIP()`, `getNetworkType()`, `isIPInCIDR()` and `isIPInAllowedList()` have the same IPv4-only limitation, so even a fully permissive policy (`networkPolicy: 'both'`, `ipAccessPolicy: 'all'`) can never satisfy an IPv6 session.

## Fix

- Added `isValidIPv6()` (uses Node's built-in `net.isIPv6`, no new dependency — `backend/package.json` doesn't currently ship an IP-handling library) and a combined `isValidIP()`, used by `validateIPAccess()`.
- Extended `isPrivateIP()`/`getNetworkType()`/`isIPInCIDR()`/`isIPInAllowedList()` to handle IPv6, using `BigInt` for 128-bit address/CIDR math (mirrors the existing 32-bit approach used for IPv4).
- `isPrivateIP()` now recognizes the IPv6 private/local ranges: `::1/128` (loopback), `fc00::/7` (unique local), `fe80::/10` (link-local).
- Added `normalizeIP()`: IPv4-mapped IPv6 addresses (`::ffff:192.0.2.1`, in both the dotted-quad and all-hex forms) are normalized to their plain IPv4 form before classification. This is the security-relevant part — without it, a dual-stack client could be classified inconsistently depending on which representation Plex reports, and a naive "every IPv6 address is WAN" implementation would silently change the meaning of an existing `lan`-only policy.
- `isValidIPv6()` (via `net.isIPv6`) accepts a zone index (e.g. `fe80::1%eth0`); it's stripped internally before the address is converted to its numeric value for CIDR/range comparisons.

`isValidIPv4()` itself is untouched, and every other IPv4 code path only gained a `normalizeIP()` pass-through, which is a no-op for a plain (non-mapped) IPv4 address — so existing IPv4 classification behavior is unchanged.

## What's out of scope

This PR touches only `ip-validation.service.ts` (see below for the callers I checked). It does **not** touch `session-termination.service.ts`, which just forwards `session.Player?.address` into `validateIPAccess()` unchanged and needs no changes for this fix.

I noticed `frontend/lib/ipUtils.ts` has its own, separate IPv4-only implementation of the same logic, used by `IPAccessModal.tsx` to validate the "allowed IPs" form field and to render the LAN/WAN badge for a device's IP. It's a near-duplicate of what's fixed here, but is a distinct module with its own consumers, so I've left it out of this PR to keep it focused and reviewable — happy to open a follow-up if that's useful.

## Testing

`backend/src/common/services/ip-validation.service.spec.ts` is a new test file (the project doesn't currently have unit tests for this service, or any `*.spec.ts` files under `src/`, so there's no existing convention to break). 70 test cases, including:

- The existing IPv4 behavior (regression coverage, run against the pre-fix code to confirm they were already passing and stay unchanged)
- Valid/invalid IPv6 forms (compressed, fully expanded, IPv4-mapped, zone index, malformed)
- Private-range classification for `::1`, `fc00::/7`, `fe80::/10`, boundaries, and a public GUA
- IPv6 CIDR matching, including exact `/128` boundaries
- Cross-family checks: an IPv4 address never matches an IPv6 CIDR and vice versa
- A mixed IPv4+IPv6 allow list
- `validateIPAccess()` end-to-end for `lan`/`wan`/`restricted` policies against IPv6 clients, plus the exact regression case from this issue (an IPv6 client under a permissive policy is no longer rejected)

Verified the new tests actually catch the bug: reverting the implementation change while keeping the tests fails 40 of 70 cases (all IPv6-related), and the IPv4 regression cases stay green either way.

```
npm run build   # clean
npx eslint src/common/services/ip-validation.service.ts   # clean
npx jest src/common/services/ip-validation.service.spec.ts   # 70 passed
npx jest   # full suite, still 70/70 (only unit tests in the repo)
```

Fixes #114